### PR TITLE
Updating native 4D-Var to IODA observation files converter

### DIFF
--- a/ioda/ioda_read.m
+++ b/ioda/ioda_read.m
@@ -22,7 +22,7 @@ function [S]=ioda_read(ncfile)
 %              S.nvars            number of variables
 %              S.epoch            IODA time reference YYYYMMDDHH
 %              S.datenum          epoch date number
-%              S.dateTimeRef      IODA time reference string     
+%              S.dateTimeRef      IODA time reference string
 %              S.variable_names   UFO/IODA standard name
 %              S.dateTime         seconds since yyyy-mm-ddTHH:MM:SSZ
 %              S.date_time        date and time ISO 8601 UTC string
@@ -42,7 +42,7 @@ function [S]=ioda_read(ncfile)
 %    Licensed under a MIT/X style license                                 %
 %    See License_ROMS.md                            Hernan G. Arango      %
 %=========================================================================%
-  
+
 % Initialize.
 
 S = struct('ncfile'           , [],                                     ...
@@ -106,7 +106,9 @@ S.variables_name = cellstr(ncread(ncfile, '/MetaData/variables_name'))';
 
 S.dateTime = double(ncread(ncfile, '/MetaData/dateTime'));
 
-S.date_time = ncread(ncfile, '/MetaData/date_time');
+if (any(strcmp({G.Variables.Name}, 'date_time')))
+  S.date_time = ncread(ncfile, '/MetaData/date_time');
+end
 
 % Set IODA NetCDF variables.
 
@@ -196,6 +198,30 @@ if (any(strcmp({I.Groups.Name}, 'hofx0')))
   end
 end
 
+if (any(strcmp({I.Groups.Name}, 'hofx0_1')))
+  for i = 1:S.nvars
+    Vname = strcat('/hofx0_1/', S.iodaVarName{i});
+    field = double(ncread(ncfile, Vname));
+    S.hofx0_1{i} = field;
+  end
+end
+
+if (any(strcmp({I.Groups.Name}, 'hofx0_2')))
+  for i = 1:S.nvars
+    Vname = strcat('/hofx0_2/', S.iodaVarName{i});
+    field = double(ncread(ncfile, Vname));
+    S.hofx0_2{i} = field;
+  end
+end
+
+if (any(strcmp({I.Groups.Name}, 'hofx0_3')))
+  for i = 1:S.nvars
+    Vname = strcat('/hofx0_3/', S.iodaVarName{i});
+    field = double(ncread(ncfile, Vname));
+    S.hofx0_3{i} = field;
+  end
+end
+
 % Read in 'hofx1' Group: Final H(x).
 
 if (any(strcmp({I.Groups.Name}, 'hofx1')))
@@ -203,6 +229,30 @@ if (any(strcmp({I.Groups.Name}, 'hofx1')))
     Vname = strcat('/hofx1/', S.iodaVarName{i});
     field = double(ncread(ncfile, Vname));
     S.hofx1{i} = field;
+  end
+end
+
+if (any(strcmp({I.Groups.Name}, 'hofx1_1')))
+  for i = 1:S.nvars
+    Vname = strcat('/hofx0_1/', S.iodaVarName{i});
+    field = double(ncread(ncfile, Vname));
+    S.hofx1_1{i} = field;
+  end
+end
+
+if (any(strcmp({I.Groups.Name}, 'hofx1_2')))
+  for i = 1:S.nvars
+    Vname = strcat('/hofx0_2/', S.iodaVarName{i});
+    field = double(ncread(ncfile, Vname));
+    S.hofx1_2{i} = field;
+  end
+end
+
+if (any(strcmp({I.Groups.Name}, 'hofx1_3')))
+  for i = 1:S.nvars
+    Vname = strcat('/hofx0_3/', S.iodaVarName{i});
+    field = double(ncread(ncfile, Vname));
+    S.hofx1_3{i} = field;
   end
 end
 

--- a/ioda/roms2ioda.m
+++ b/ioda/roms2ioda.m
@@ -1,9 +1,10 @@
-function roms2ioda(ObsData, HisName, prefix, suffix)
+function roms2ioda(ObsData, HisName, prefix, suffix, varargin)
 
 %
 % ROMS2IODA:  Converts ROMS observation NetCDF to IODA NetCDF4 files
 %
-% roms2ioda(ObsData, HisName)
+% roms2ioda(ObsData, HisName, prefix, suffix, ...
+%           SSHareaAvg, SSHtimeAvg, UVtimeAvg)
 %
 % This function converts a ROMS 4D-Var observation NetCDF file into several
 % IODA NetCDF files. One file per each observation type is usually the way
@@ -13,6 +14,9 @@ function roms2ioda(ObsData, HisName, prefix, suffix)
 %
 % For example:           wc13_sst_20040103.nc4
 %
+% The area-averaged and time-averaged values will be used in ROMS H(x)
+% computations with area-averaged and/or time-averaged filters.
+%
 % On Input:
 %
 %    ObsData     ROMS standard 4D-Var observation NetCDF filename (string)
@@ -21,7 +25,7 @@ function roms2ioda(ObsData, HisName, prefix, suffix)
 %    HisName     ROMS application history NetCDF filename (string)
 %
 %    prefix      Output file prefix associated with application (string)
-%   
+%
 %    suffix      Output file suffix associated with date and time, use
 %                  YYYYMMDD or YYYYMMDDhh (numeric or string).
 %
@@ -31,11 +35,40 @@ function roms2ioda(ObsData, HisName, prefix, suffix)
 %                  For example, if suffix =  20040103  or
 %                                  suffix = '20040103' then
 %
-%            int64 dateTime(Location);
+%                  int64 dateTime(Location);
 %                  dateTime:units = "seconds since 2004-01-03T00:00:00Z";
 %
 %                  Therefore, input and output time of the observations
 %                  may have different time references!
+%
+%    SSHareaAvg  SSH observations area-averaged radius (km, OPTIONAL)
+%                  Use unique SSH observations (remove repetitive)
+%
+%                  float spatialAverage
+%
+%    SSHtimeAvg  SSH observations time-averaged window since reference
+%                  time (hours; OPTIONAL).
+%
+%                  For example 24 hours, 2004-01-03 to 2004-01-04
+%                                        2004-01-04 to 2004-01-05
+%                                        2004-01-05 to 2004-01-06
+%                                        and so on ...
+%
+%                  int64 dateTimeAverageStart(timeWindow);
+%
+%                  int64 dateTimeAverageEnd(timeWindow);
+%
+%    UVtimeAvg   CODAR observations time-averaged window since reference
+%                  time (hours; OPTIONAL)
+%
+%                  For example 24 hours, 2004-01-03 to 2004-01-04
+%                                        2004-01-04 to 2004-01-05
+%                                        2004-01-05 to 2004-01-06
+%                                        and so on ...
+%
+%                  int64 dateTimeAverageStart(timeWindow);
+%
+%                  int64 dateTimeAverageEnd(timeWindow);
 %
 % Usage: Example to convert WC13 4D-Var observation file to create the
 %        following IODA-2 files:
@@ -64,6 +97,25 @@ function roms2ioda(ObsData, HisName, prefix, suffix)
 %=========================================================================%
 
 % Initialize.
+
+switch numel(varargin)
+  case 0
+    SSHareaAvg = NaN;
+    SSHtimeAvg = NaN;
+    UVtimeAvg  = NaN;
+  case 1
+    SSHareaAvg = varargin{1};
+    SSHtimeAvg = NaN;
+    UVtimeAvg  = NaN;
+  case 2
+    SSHareaAvg = varargin{1};
+    SSHtimeAvg = varargin{2};
+    UVtimeAvg  = NaN;
+  case 3
+    SSHareaAvg = varargin{1};
+    SSHtimeAvg = varargin{2};
+    UVtimeAvg  = varargin{3};
+end
 
 if (ischar(ObsData))
   S = obs_read(ObsData);
@@ -108,6 +160,10 @@ end
 S.Zgrid = S.depth;
 S = obs_k2z(S, HisName);
 
+% Estimate data assimilation cycle time-window.
+
+days_window = floor((max(S.time)-min(S.time))+0.5);
+
 %--------------------------------------------------------------------------
 % Inquire observation structure about type meassurent types.
 %--------------------------------------------------------------------------
@@ -129,6 +185,28 @@ iuvel = find(S.type == 4);
 ivvel = find(S.type == 5);
 itemp = find(S.type == 6);
 isalt = find(S.type == 7);
+
+% Currently, one of the strategies to improve the impact of altimetry
+% track data is to repeat their observations several times over the
+% assimilation cycle, but with different errors.
+%
+% Identify such repetitive observations by setting their provenance
+% to negative values.
+
+if (~isempty(issh))
+  [~,IA,~] = unique(complex(S.lat(issh), S.lon(issh)));
+  if (~isempty(IA))
+    sshProv = -abs(S.provenance(issh));      % Set negative SSH provenance
+    for n = 1:length(IA)
+      sshProv(IA(n))= -sshProv(IA(n));       % Turn positive unique values
+    end
+    S.provenance(issh) = sshProv;            % overwrite SSH provenance
+  end
+
+  if (~isnan(SSHareaAvg) || ~isnan(SShtimeAbg))
+    issh = find(S.provenance(issh) > 0);
+  end
+end
 
 % Get provenance indices for each state variable.
 
@@ -175,14 +253,30 @@ if (got_ssh)
     has_depth  = false;
     Obs = extract_observations(S, issh, DateTimeIODA, has_depth);
     Obs.ncfile         = [prefix '_adt_' suffix '.nc4'];
+    Obs.N              = G.N;
     Obs.nvars          = 1;
     Obs.units          = {'meter'};
     Obs.ncvname        = {'absoluteDynamicTopography'};
+    Obs.stateID        = 1;
+    Obs.areaAvgRadius  = SSHareaAvg;
+    Obs.timeAvgWindow  = SSHtimeAvg;
     Obs.variables_name = {'absolute_dynamic_topography'};
     Obs.datetime_ref   = DateTimeIODA;
     if (got_flagAtt)
       Obs.flag_values   = int32(P.flag_values(P.ssh));
       Obs.flag_meanings = string(join(P.flag_meanings(P.ssh)));
+    end
+    if (~isnan(SSHareaAvg))
+      Obs.areaAvgRadius = SSHareaAvg * 1000;        % to meters
+    end
+    if (~isnan(SSHtimeAvg))
+      delta  = SSHtimeAvg * 3600;                    % to secods
+      window = days_window * 86400;
+      Tstr = 0:delta:window-delta;
+      Tend = delta:delta:window;
+      Obs.timeAvgBegin = Tstr;
+      Obs.timeAvgEnd   = Tend;
+      Obs.nwindow      = length(Tstr);
     end
     create_ioda_obs(Obs);
     write_observations(Obs);
@@ -191,15 +285,17 @@ end
 
 % Process sea surface temperature.
 
-if (got_temp)     
+if (got_temp)
   isst = find(S.type == 6 & S.Zgrid == G.N);
   if (~isempty(isst))
     has_depth = false;
     Obs = extract_observations(S, isst, DateTimeIODA, has_depth);
     Obs.ncfile         = [prefix '_sst_' suffix '.nc4'];
+    Obs.N              = G.N;
     Obs.nvars          = 1;
     Obs.units          = {'C'};
     Obs.ncvname        = {'seaSurfaceTemperature'};
+    Obs.stateID        = 6;
     Obs.variables_name = {'sea_surface_temperature'};
     Obs.datetime_ref   = DateTimeIODA;
     if (got_flagAtt)
@@ -219,14 +315,16 @@ end
 
 % Process sub-surface insitu temperature.
 
-if (got_temp)     
+if (got_temp)
   ktemp = find(S.type == 6 & S.Zgrid ~= G.N);
   if (~isempty(ktemp))
     has_depth = true;
     Obs = extract_observations(S, ktemp, DateTimeIODA, has_depth);
     Obs.ncfile         = [prefix '_temp_' suffix '.nc4'];
+    Obs.N              = G.N;
     Obs.nvars          = 1;
     Obs.units          = {'C'};
+    Obs.stateID        = 6;
     Obs.ncvname        = {'waterTemperature'};
     Obs.variables_name = {'sea_water_temperature'};
     Obs.datetime_ref   = DateTimeIODA;
@@ -234,12 +332,12 @@ if (got_temp)
       sst_ind = contains(upper(P.flag_meanings(P.temp)), 'SST');
       if (any(sst_ind))                             % remove SST provenance
         P.temp(sst_ind)   = [];
-	Obs.flag_values   = int32(P.flag_values(P.temp));
+        Obs.flag_values   = int32(P.flag_values(P.temp));
         Obs.flag_meanings = string(join(P.flag_meanings(P.temp)));
-      else 
-	Obs.flag_values   = int32(P.flag_values(P.temp));
+      else
+        Obs.flag_values   = int32(P.flag_values(P.temp));
         Obs.flag_meanings = string(join(P.flag_meanings(P.temp)));
-      end      
+      end
     end
     create_ioda_obs(Obs);
     write_observations(Obs);
@@ -250,34 +348,36 @@ end
 % observations in the input NetCDF are insitu temperature. Below, they
 % are converted to potential temperature.
 
-if (got_temp)     
+if (got_temp)
   ktemp = find(S.type == 6 & S.Zgrid ~= G.N);
   if (~isempty(ktemp))
     has_depth = true;
     Obs = extract_observations(S, ktemp, DateTimeIODA, has_depth);
-    
+
     p = sw_pres(abs(Obs.depth), Obs.latitude);      % decibars
     s = ones(size(Obs.ObsValue)).*35.0;
     pr = zeros(size(Obs.ObsValue));
     ptemp = sw_ptmp(s, Obs.ObsValue, p, pr);
     Obs.ObsValue = ptemp;
-    
+
     Obs.ncfile         = [prefix '_ptemp_' suffix '.nc4'];
+    Obs.N              = G.N;
     Obs.nvars          = 1;
     Obs.units          = {'C'};
     Obs.ncvname        = {'waterPotentialTemperature'};
+    Obs.stateID        = 6;
     Obs.variables_name = {'sea_water_potential_temperature'};
     Obs.datetime_ref   = DateTimeIODA;
     if (got_flagAtt)
       sst_ind = contains(upper(P.flag_meanings(P.temp)), 'SST');
       if (any(sst_ind))                             % remove SST provenance
         P.temp(sst_ind)   = [];
-	Obs.flag_values   = int32(P.flag_values(P.temp));
+        Obs.flag_values   = int32(P.flag_values(P.temp));
         Obs.flag_meanings = string(join(P.flag_meanings(P.temp)));
-      else 
-	Obs.flag_values   = int32(P.flag_values(P.temp));
+      else
+        Obs.flag_values   = int32(P.flag_values(P.temp));
         Obs.flag_meanings = string(join(P.flag_meanings(P.temp)));
-      end      
+      end
     end
     create_ioda_obs(Obs);
     write_observations(Obs);
@@ -286,14 +386,16 @@ end
 
 % Process salinity.
 
-if (got_salt)     
+if (got_salt)
   if (~isempty(isalt))
     has_depth = true;
     Obs = extract_observations(S, isalt, DateTimeIODA, has_depth);
     Obs.ncfile         = [prefix '_salt_' suffix '.nc4'];
+    Obs.N              = G.N;
     Obs.nvars          = 1;
     Obs.units          = {'dimensionless'};
     Obs.ncvname        = {'salinity'};
+    Obs.stateID        = 7;
     Obs.variables_name = {'sea_water_salinity'};
     Obs.datetime_ref   = DateTimeIODA;
     if (got_flagAtt)
@@ -305,35 +407,98 @@ if (got_salt)
   end
 end
 
+% Process gridded HF radar near surface (z=-2 m) velocities. The
+% CODAR velocity components in the native ROMS observation file
+% are rotated to grid curvilinear coordinates, we need to rotate
+% back to geographycal EAST and NORTH directions before they are
+% written to the IODA-type file.
+
+if (got_uvel && got_vvel)
+  if ~(isempty(iuvel) || isempty(iuvel))
+    has_depth = true;
+    Uobs = extract_observations(S, iuvel, DateTimeIODA, has_depth);
+    Vobs = extract_observations(S, ivvel, DateTimeIODA, has_depth);
+    Obs  = Uobs;
+    Obs.ObsError       = [];
+    Obs.ObsError{1}    = Uobs.ObsError;
+    Obs.ObsError{2}    = Vobs.ObsError;
+    Obs.ObsValue       = [];
+    Obs.ObsValue{1}    = Uobs.ObsValue;
+    Obs.ObsValue{2}    = Vobs.ObsValue;
+    Obs.PreQC          = [];
+    Obs.PreQC{1}       = Uobs.PreQC;
+    Obs.PreQC{2}       = Uobs.PreQC;
+    Obs.ncfile         = [prefix '_uv_codar_' suffix '.nc4'];
+    Obs.N              = G.N;
+    Obs.nvars          = 2;
+    Obs.units          = {'m s-1', 'm s-1'};
+    Obs.ncvname        = {'waterZonalVelocity',                      ...
+                          'waterMeridionalVelocity'};
+    Obs.stateID        = [4, 5];
+    Obs.timeAvgWindow  = UVtimeAvg;
+    Obs.variables_name = {'eastward_sea_water_velocity',             ...
+                          'meridional_sea_water_velocity'};
+    Obs.datetime_ref   = DateTimeIODA;
+    if (got_flagAtt)
+      Obs.flag_values   = int32(P.flag_values(P.uvel));
+      Obs.flag_meanings = string(join(P.flag_meanings(P.uvel)));
+    end
+    if (~isnan(UVtimeAvg))
+      delta  = UVtimeAvg * 3600;                    % to secods
+      window = days_window * 86400;
+      Tstr = 0:delta:window-delta;
+      Tend = delta:delta:window;
+      Obs.timeAvgBegin = Tstr;
+      Obs.timeAvgEnd   = Tend;
+      Obs.nwindow      = length(Tstr);
+    end
+    Obs = rotate_codar(Obs, G);
+    create_ioda_obs(Obs);
+    write_observations(Obs);
+  end
+end
+
 return
 
 %--------------------------------------------------------------------------
 % Extract requested observation type from structure.
 
-function [Obs] = extract_observations(S, ind, DateTimeIODA, has_depth);
+function [Obs] = extract_observations(S, ind, DateTimeIODA, has_depth)
 
 % Initialize structure.
 
 Obs = struct('ncfile'        , [],                                      ...
              'source'        , [],                                      ...
+             'N'             , [],                                      ...
              'nlocs'         , [],                                      ...
              'nobs'          , [],                                      ...
+             'nsurvey'       , [],                                      ...
              'nvars'         , [],                                      ...
+             'nwindow'       , NaN,                                     ...
              'units'         , [],                                      ...
              'ncvname'       , [],                                      ...
              'variable_names', [],                                      ...
              'TimeIODA'      , [],                                      ...
-	     'DateIODA'      , [],                                      ...
+             'DateIODA'      , [],                                      ...
              'dateTime'      , [],                                      ...
+             'surveyTime'    , [],                                      ...
+             'surveyIndex'   , [],                                      ...
              'date_time'     , [],                                      ...
              'depth'         , [],                                      ...
              'latitude'      , [],                                      ...
              'longitude'     , [],                                      ...
              'provenance'    , [],                                      ...
+             'stateID'       , [],                                      ...
              'sequenceNumber', [],                                      ...
+             'areaAvgRadius' , NaN,                                     ...
+             'timeAvgBegin'  , NaN,                                     ...
+             'timeAvgEnd'    , NaN,                                     ...
+             'x_grid'        , [],                                      ...
+             'y_grid'        , [],                                      ...
+             'z_grid'        , [],                                      ...
              'ObsError'      , [],                                      ...
-	     'ObsValue'      , [],                                      ...
-	     'PreQC'         , []);
+             'ObsValue'      , [],                                      ...
+             'PreQC'         , []);
 
 % Fill some values in the structure.
 
@@ -349,20 +514,30 @@ Obs.latitude       = S.lat(ind);
 Obs.longitude      = S.lon(ind);
 Obs.provenance     = S.provenance(ind);
 Obs.sequenceNumber = int32(1:Obs.nlocs);
+Obs.x_grid         = S.Xgrid(ind);
+Obs.y_grid         = S.Ygrid(ind);
+if (has_depth)
+  Obs.z_grid       = S.Zgrid(ind);
+end
 Obs.ObsError       = sqrt(S.error(ind));              % standard deviation
 Obs.ObsValue       = S.value(ind);
 Obs.PreQC          = int32(zeros(size(Obs.longitude)));
 
 % Compute dateTime seconds from IODA file reference time.
 
-ioda_epoch     = datenum(num2str(DateTimeIODA), 'yyyymmddHH');
+ioda_epoch      = datenum(num2str(DateTimeIODA), 'yyyymmddHH');
 
-time_days      = S.reference_time + S.time(ind);
-ioda_time_days = time_days - ioda_epoch;        
+time_days       = S.reference_time + S.time(ind);
+ioda_time_days  = time_days - ioda_epoch;
 
-Obs.dateTime   = int64(ioda_time_days * 86400);        % seconds
+Obs.dateTime    = int64(ioda_time_days * 86400);      % seconds
 
-Obs.date_time  = cellstr(datestr(ioda_epoch + ioda_time_days,          ...
+[survey,IA,IC]  = unique(Obs.dateTime, 'stable');
+Obs.surveyTime  = int64(survey);
+Obs.surveyIndex = int32(IA);
+Obs.nsurvey     = length(Obs.surveyTime);
+
+Obs.date_time   = cellstr(datestr(ioda_epoch + ioda_time_days,          ...
                                  'yyyy-mm-ddTHH:MM:SSZ'));
 
 % Set IODA file time reference global attributes.
@@ -373,16 +548,56 @@ Obs.DateIODA = datestr(ioda_epoch, 'yyyy-mm-ddTHH:MM:SSZ');
 return
 
 %--------------------------------------------------------------------------
+% Extract requested observation type from structure.
+
+function [Obs] = rotate_codar (S, G)
+
+% Interpolate ROMS curvilinear angle to CODAR observation locations.
+% Use scatteredInterpolant since horizontal grid coordinates are not
+% plaid.
+
+F = scatteredInterpolant(G.lon_rho(:), G.lat_rho(:), G.angle(:));
+
+angle = F(S.longitude, S.latitude);
+
+% Rotate velocity component to geographical EAST and NORTH.
+
+Urot = S.ObsValue{1};
+Vrot = S.ObsValue{2};
+
+cos_angle = cos(angle);
+sin_angle = sin(angle);
+
+Ugeo = Urot .* cos_angle - Vrot .* sin_angle;
+Vgeo = Vrot .* cos_angle + Urot .* sin_angle;
+
+% Replace velocity components.
+
+Obs = S;
+
+Obs.ObsValue{1} = Ugeo;
+Obs.ObsValue{2} = Vgeo;
+
+return
+
+%--------------------------------------------------------------------------
 % Writes requested observation type data to ouput NetCDF file.
 
-function write_observations(Obs);
+function write_observations(Obs)
 
 disp(['*** Writing  observations file:  ', Obs.ncfile]);
 
 % Write out 'MetaData' Group variables.
 
 ncwrite(Obs.ncfile, 'MetaData/dateTime', int64(Obs.dateTime));
-ncwrite(Obs.ncfile, 'MetaData/date_time', Obs.date_time);
+if (~isnan(Obs.timeAvgBegin))
+  ncwrite(Obs.ncfile, 'MetaData/dateTimeAverageBegin',                  ...
+          int64(Obs.timeAvgBegin));
+end
+if (~isnan(Obs.timeAvgEnd))
+  ncwrite(Obs.ncfile, 'MetaData/dateTimeAverageEnd',                    ...
+          int64(Obs.timeAvgEnd));
+end
 if (~isempty(Obs.depth))
   ncwrite(Obs.ncfile, 'MetaData/depth', Obs.depth);
 end
@@ -391,27 +606,53 @@ ncwrite(Obs.ncfile, 'MetaData/longitude', Obs.longitude);
 if (~isempty(Obs.provenance))
   ncwrite(Obs.ncfile, 'MetaData/provenance', Obs.provenance);
 end
+ncwrite(Obs.ncfile, 'MetaData/stateID', int32(Obs.stateID));
 ncwrite(Obs.ncfile, 'MetaData/sequenceNumber', Obs.sequenceNumber);
+if (~isnan(Obs.areaAvgRadius))
+  ncwrite(Obs.ncfile, 'MetaData/spatialAverage', Obs.areaAvgRadius);
+end
+ncwrite(Obs.ncfile, 'MetaData/surveyIndex', int32(Obs.surveyIndex));
+ncwrite(Obs.ncfile, 'MetaData/surveyTime', int64(Obs.surveyTime));
 ncwrite(Obs.ncfile, 'MetaData/variables_name', Obs.variables_name);
+ncwrite(Obs.ncfile, 'MetaData/x_grid', Obs.x_grid);
+ncwrite(Obs.ncfile, 'MetaData/y_grid', Obs.y_grid);
+if (~isempty(Obs.z_grid))
+  ncwrite(Obs.ncfile, 'MetaData/z_grid', Obs.z_grid);
+end
 
 % Write out 'ObsError' Group variables.
 
-for i = 1:Obs.nvars
-  Vname = ['/ObsError/' Obs.ncvname{i}];
-  ncwrite(Obs.ncfile, Vname, Obs.ObsError{i});
+if (iscell(Obs.ObsError))
+  for i = 1:Obs.nvars
+    Vname = ['/ObsError/' Obs.ncvname{i}];
+    ncwrite(Obs.ncfile, Vname, Obs.ObsError{i});
+  end
+else
+  Vname = ['/ObsError/' char(Obs.ncvname)];
+  ncwrite(Obs.ncfile, Vname, Obs.ObsError);
 end
 
 % Write out 'ObsValue' Group variables.
 
-for i = 1:Obs.nvars
-  Vname = ['/ObsValue/' Obs.ncvname{i}];
+if (iscell(Obs.ObsValue))
+  for i = 1:Obs.nvars
+    Vname = ['/ObsValue/' Obs.ncvname{i}];
+    ncwrite(Obs.ncfile, Vname, Obs.ObsValue{i});
+  end
+else
+  Vname = ['/ObsValue/' char(Obs.ncvname)];
   ncwrite(Obs.ncfile, Vname, Obs.ObsValue);
 end
 
 % Write out 'ObsQC' Group variables.
 
-for i = 1:Obs.nvars
-  Vname = ['/PreQC/' Obs.ncvname{i}];
+if (iscell(Obs.PreQC))
+  for i = 1:Obs.nvars
+    Vname = ['/PreQC/' Obs.ncvname{i}];
+    ncwrite(Obs.ncfile, Vname, Obs.PreQC{i});
+  end
+else
+  Vname = ['/PreQC/' char(Obs.ncvname)];
   ncwrite(Obs.ncfile, Vname, Obs.PreQC);
 end
 

--- a/utility/plot_section.m
+++ b/utility/plot_section.m
@@ -57,13 +57,13 @@ function F=plot_section(Gname, Hname, Vname, Tindex, orient, index,     ...
 %    Licensed under a MIT/X style license                                 %
 %    See License_ROMS.md                            Hernan G. Arango      %
 %=========================================================================%
-  
+
 % Initialize.
 
 if (orient == 'c')
   F = struct('ncname'     , [], 'Vname'     , [],                       ...
              'Tindex'     , [], 'Tname'     , [], 'Tstring'   , [],     ...
-	     'column'     , [],                                         ...
+             'column'     , [],                                         ...
              'value'      , [], 'min'       , [], 'max'       , [],     ...
              'X'          , [], 'Z'         , [],                       ...
              'Imin'       , [], 'Jmin'      , [],                       ...
@@ -72,7 +72,7 @@ if (orient == 'c')
 else
   F = struct('ncname'     , [], 'Vname'     , [],                       ...
              'Tindex'     , [], 'Tname'     , [], 'Tstring'   , [],     ...
-	     'row'        , [],                                         ...
+             'row'        , [],                                         ...
              'value'      , [], 'min'       , [], 'max'       , [],     ...
              'X'          , [], 'Z'         , [],                       ...
              'Imin'       , [], 'Jmin'      , [],                       ...
@@ -180,7 +180,7 @@ end
 
 if (getdata)
 
-  V = nc_vnames(Hname);  
+  V = nc_vnames(Hname);
 
   switch (Vname)
     case {'Hz', 'hz'}
@@ -189,7 +189,7 @@ if (getdata)
       else
         I = nc_vinfo(Hname, 'z_w');
       end
-    otherwise 
+    otherwise
       I = nc_vinfo(Hname, Vname);
   end
 
@@ -336,7 +336,7 @@ if (getdata)
     N = size(Z,3);
   else
     error([' PLOT_SECTION - cannot plot a section for a 2D field: ''',  ...
-	   Vname, ''])
+           Vname, ''])
   end
 
   if (isfield(G,Mname))
@@ -352,8 +352,10 @@ if (getdata)
   end
 
   if (~G.spherical)
-    X = 0.001 .* X;
-    Y = 0.001 .* Y;
+    if (max(X(:)) > 5000 || max(Y(:)) > 5000)
+      X = 0.001 .* X;                           % scale to kilometers
+      Y = 0.001 .* Y;
+    end
   end
 end
 
@@ -401,7 +403,7 @@ if (getdata)
       Z = G.z_r;
    otherwise
       field = nc_read(Hname,Vname,Tindex,ReplaceValue,PreserveType);
-  end  
+  end
 
 end
 
@@ -435,7 +437,7 @@ switch orient
       x = squeeze(G.x_rho(:,index));
     end
     z = -squeeze(G.h(:,index));
-end    
+end
 
 V = V .* scale;
 
@@ -493,7 +495,7 @@ if (ptype ~= 0)
   hold on;
   area(x, z, min(z), 'FaceColor', Land, 'EdgeColor', Land);
   hold off;
-  
+
   if (~isempty(Tname))
     ht = title([untexlabel(Vname), ':', blanks(4),                      ...
                 'Record = ', num2str(Tindex), ',', blanks(4),           ...

--- a/utility/scoord.m
+++ b/utility/scoord.m
@@ -97,7 +97,7 @@ end,
 if (Vtransform < 1 | Vtransform > 2),
   disp(' ');
   disp([setstr(7),'*** Error:  SCOORD - Illegal parameter Vtransform = ' ...
-        num2str(Vtransfrom), setstr(7)]);
+        num2str(Vtransform), setstr(7)]);
   return
 end,
 


### PR DESCRIPTION
# Description

This PR updates the native **ROMS** to the **IODA-type** observation files converter, **`roms2ioda.m`**. The generic **JEDI** data assimilation framework uses the **IODA-type** observation files. It is an enhanced **NetCDF-4** with first-level grouping and the extension **nc4** for differentiation.

Usually, one **IODA-type** file is available for each variable in the **control** vector, like **SSH**, **SST**, **SSS**,  **HF radar velocities**, **temperature**, and **salinity** files for a particular data assimilation cycle. A file can include multiple variables representing vectors (u- and v-momentum) and spectral data with exact coordinates (lon, lat, depth, time). It may also contain multiple scalar variables if at the precise location, such as **T** and **S** profiles or biological profiles for various ecosystem state variables. I may also include secondary variables to compute a **control** variable with an elaborate operator. This setup gives us a lot of flexibility for filtering and averaging operators.

The **native ROMS 4D-Var** data assimilation operators are being restructured to allow multiple **IODA-type** files. This facilitates area-averaged and/or time-averaged **H(x)** operators that compute model solutions at the observation locations. This capability will be available soon. 

---

The main objective of the restructuring is to have **IODA-type** observation files that can be used either in the **native ROMS 4D-Var** drivers or in any of the **ROMS-JEDI** data assimilation algorithms. Also, sophisticated **H(x)** operators will be available in the **native ROMS 4D-Var** algorithms.  For more details, please check https://github.com/myroms/roms/pull/62.

---

For example, the **IODA-type NetCDF-4** schema for **SSH** observations that require an area-averaged (60 km) and time-averaged (36-hour) filter in the **H(x)** operator is as follows:

``` c
% ncdump -t -v dateTimeAverageBegin,dateTimeAverageEnd,spatialAverage usec3_adt_20190827.nc4

netcdf usec3_adt_20190827 {
dimensions:
	Location = 1940 ;
	nvars = 1 ;
	survey = 17 ;
	timeWindow = 2 ;
variables:
	int Location(Location) ;
		Location:suggested_chunck_dim = 512 ;
	int nvars(nvars) ;
		nvars:suggested_chunck_dim = 100 ;
	int survey(survey) ;
		survey:suggested_chunck_dim = 100 ;
	int timeWindow(timeWindow) ;
		timeWindow:suggested_chunck_dim = 100 ;

// global attributes:
		:_ioda_layout = "ObsGroup" ;
		:_ioda_layout_version = 3 ;
		:odb_version = 1 ;
		:date_time = 2019082700. ;
		:datetimeReference = "2019-08-27T00:00:00Z" ;
		:description = "Native ROMS 4D-Var observations file converted to IODA" ;
		:sourceFiles = "usec3km_roms_obs_20190827.nc" ;
		:history = "Created from Matlab script: create_ioda_obs on Monday - August 4, 2025 - 3:25:57.5804 PM" ;
data:

group: MetaData {
  variables:
  	int64 dateTime(Location) ;
  		dateTime:long_name = "elapsed observation time since reference" ;
  		dateTime:units = "seconds since 2019-08-27T00:00:00Z" ;
  	int64 dateTimeAverageBegin(timeWindow) ;
  		dateTimeAverageBegin:long_name = "start of time averaging filter" ;
  		dateTimeAverageBegin:units = "seconds since 2019-08-27T00:00:00Z" ;
  	int64 dateTimeAverageEnd(timeWindow) ;
  		dateTimeAverageEnd:long_name = "end of time averaging filter" ;
  		dateTimeAverageEnd:units = "seconds since 2019-08-27T00:00:00Z" ;
  	float latitude(Location) ;
  		latitude:long_name = "observation latitude" ;
  		latitude:units = "degrees_north" ;
  	float longitude(Location) ;
  		longitude:long_name = "observation longitude" ;
  		longitude:units = "degrees_east" ;
  	int provenance(Location) ;
  		provenance:long_name = "observation origin identifier" ;
  		provenance:negative = "repetitive observation at different times and error" ;
  	int sequenceNumber(Location) ;
  		sequenceNumber:long_name = "observation sequence number" ;
  	float spatialAverage ;
  		spatialAverage:long_name = "half-length of spatial averaging filter" ;
  		spatialAverage:units = "meter" ;
  	int stateID(nvars) ;
  		stateID:long_name = "state variable index" ;
  	int surveyIndex(survey) ;
  		surveyIndex:long_name = "observation survey time indices as they appear in dateTime" ;
  	int64 surveyTime(survey) ;
  		surveyTime:long_name = "observation survey time" ;
  		surveyTime:units = "seconds since 2019-08-27T00:00:00Z" ;
  	string variables_name(nvars) ;
  		variables_name:long_name = "observation UFO/IODA standard name" ;
  		string variables_name:_FillValue = "" ;
  	float x_grid(Location) ;
  		x_grid:long_name = "observation fractional x-grid location" ;
  	float y_grid(Location) ;
  		y_grid:long_name = "observation fractional y-grid location" ;
  data:

   dateTimeAverageBegin = "2019-08-27", "2019-08-28 12" ;

   dateTimeAverageEnd = "2019-08-28 12", "2019-08-30" ;

   spatialAverage = 30000 ;
  } // group MetaData

group: ObsError {
  variables:
  	float absoluteDynamicTopography(Location) ;
  		absoluteDynamicTopography:long_name = "observation error standard deviation" ;
  		absoluteDynamicTopography:units = "meter" ;
  		absoluteDynamicTopography:coordinates = "longitude, latitude, dateTime" ;
  data:
  } // group ObsError

group: ObsValue {
  variables:
  	float absoluteDynamicTopography(Location) ;
  		absoluteDynamicTopography:long_name = "observation value" ;
  		absoluteDynamicTopography:units = "meter" ;
  		absoluteDynamicTopography:coordinates = "longitude, latitude, dateTime" ;
  data:
  } // group ObsValue

group: PreQC {
  variables:
  	int absoluteDynamicTopography(Location) ;
  		absoluteDynamicTopography:long_name = "observation preset quality control filter identifier" ;
  		absoluteDynamicTopography:coordinates = "longitude, latitude, dateTime" ;
  data:
  } // group PreQC
}
```
---

For HF radar velocity observations at a depth of 2 m, which computes an **H(x)** with a 24-hour time-averaged filter :

``` c
% ncdump -t -v dateTimeAverageBegin,dateTimeAverageEnd usec3_uv_codar_20190827.nc4

netcdf usec3_uv_codar_20190827 {
dimensions:
	Location = 10332 ;
	nvars = 2 ;
	survey = 72 ;
	timeWindow = 3 ;
variables:
	int Location(Location) ;
		Location:suggested_chunck_dim = 512 ;
	int nvars(nvars) ;
		nvars:suggested_chunck_dim = 100 ;
	int survey(survey) ;
		survey:suggested_chunck_dim = 100 ;
	int timeWindow(timeWindow) ;
		timeWindow:suggested_chunck_dim = 100 ;

// global attributes:
		:_ioda_layout = "ObsGroup" ;
		:_ioda_layout_version = 3 ;
		:odb_version = 1 ;
		:date_time = 2019082700. ;
		:datetimeReference = "2019-08-27T00:00:00Z" ;
		:description = "Native ROMS 4D-Var observations file converted to IODA" ;
		:sourceFiles = "usec3km_roms_obs_20190827.nc" ;
		:history = "Created from Matlab script: create_ioda_obs on Monday - August 4, 2025 - 3:26:0.62598 PM" ;
data:

group: MetaData {
  variables:
  	int64 dateTime(Location) ;
  		dateTime:long_name = "elapsed observation time since reference" ;
  		dateTime:units = "seconds since 2019-08-27T00:00:00Z" ;
  	int64 dateTimeAverageBegin(timeWindow) ;
  		dateTimeAverageBegin:long_name = "start of time averaging filter" ;
  		dateTimeAverageBegin:units = "seconds since 2019-08-27T00:00:00Z" ;
  	int64 dateTimeAverageEnd(timeWindow) ;
  		dateTimeAverageEnd:long_name = "end of time averaging filter" ;
  		dateTimeAverageEnd:units = "seconds since 2019-08-27T00:00:00Z" ;
  	float depth(Location) ;
  		depth:long_name = "observation depth below sea level" ;
  		depth:units = "meter" ;
  		depth:negative = "downwards" ;
  	float latitude(Location) ;
  		latitude:long_name = "observation latitude" ;
  		latitude:units = "degrees_north" ;
  	float longitude(Location) ;
  		longitude:long_name = "observation longitude" ;
  		longitude:units = "degrees_east" ;
  	int provenance(Location) ;
  		provenance:long_name = "observation origin identifier" ;
  	int sequenceNumber(Location) ;
  		sequenceNumber:long_name = "observation sequence number" ;
  	int stateID(nvars) ;
  		stateID:long_name = "state variable index" ;
  	int surveyIndex(survey) ;
  		surveyIndex:long_name = "observation survey time indices as they appear in dateTime" ;
  	int64 surveyTime(survey) ;
  		surveyTime:long_name = "observation survey time" ;
  		surveyTime:units = "seconds since 2019-08-27T00:00:00Z" ;
  	string variables_name(nvars) ;
  		variables_name:long_name = "observation UFO/IODA standard name" ;
  		string variables_name:_FillValue = "" ;
  	float x_grid(Location) ;
  		x_grid:long_name = "observation fractional x-grid location" ;
  	float y_grid(Location) ;
  		y_grid:long_name = "observation fractional y-grid location" ;
  	float z_grid(Location) ;
  		z_grid:long_name = "observation fractional z-grid location" ;
  data:

   dateTimeAverageBegin = "2019-08-27", "2019-08-28", "2019-08-29" ;

   dateTimeAverageEnd = "2019-08-28", "2019-08-29", "2019-08-30" ;
  } // group MetaData

group: ObsError {
  variables:
  	float waterZonalVelocity(Location) ;
  		waterZonalVelocity:long_name = "observation error standard deviation" ;
  		waterZonalVelocity:units = "m s-1" ;
  		waterZonalVelocity:coordinates = "longitude, latitude, depth, dateTime" ;
  	float waterMeridionalVelocity(Location) ;
  		waterMeridionalVelocity:long_name = "observation error standard deviation" ;
  		waterMeridionalVelocity:units = "m s-1" ;
  		waterMeridionalVelocity:coordinates = "longitude, latitude, depth, dateTime" ;
  data:
  } // group ObsError

group: ObsValue {
  variables:
  	float waterZonalVelocity(Location) ;
  		waterZonalVelocity:long_name = "observation value" ;
  		waterZonalVelocity:units = "m s-1" ;
  		waterZonalVelocity:coordinates = "longitude, latitude, depth, dateTime" ;
  	float waterMeridionalVelocity(Location) ;
  		waterMeridionalVelocity:long_name = "observation value" ;
  		waterMeridionalVelocity:units = "m s-1" ;
  		waterMeridionalVelocity:coordinates = "longitude, latitude, depth, dateTime" ;
  data:
  } // group ObsValue

group: PreQC {
  variables:
  	int waterZonalVelocity(Location) ;
  		waterZonalVelocity:long_name = "observation preset quality control filter identifier" ;
  		waterZonalVelocity:coordinates = "longitude, latitude, depth, dateTime" ;
  	int waterMeridionalVelocity(Location) ;
  		waterMeridionalVelocity:long_name = "observation preset quality control filter identifier" ;
  		waterMeridionalVelocity:coordinates = "longitude, latitude, depth, dateTime" ;
  data:
  } // group PreQC
}
```

---

These **IODA-type** observation files are easily generated with the **`roms2ioda.m`** conversion script:

``` d
>> Hname='/home/arango/ROMS/Projects/USEC/RBL4DVAR_mixres/Set01/2019.08.27usec3km_roms_fwd_20190827_outer0.nc';
>> cd /home/arango/ocean/repository/git/roms_test/USEC/Data/OBS

>> roms2ioda('usec3km_roms_obs_20190827.nc',Hname,'usec3','20190827',30,36,24);
 
*** Creating observations file:  usec3_adt_20190827.nc4
*** Writing  observations file:  usec3_adt_20190827.nc4
 
*** Creating observations file:  usec3_sst_20190827.nc4
*** Writing  observations file:  usec3_sst_20190827.nc4
 
*** Creating observations file:  usec3_temp_20190827.nc4
*** Writing  observations file:  usec3_temp_20190827.nc4
 
*** Creating observations file:  usec3_ptemp_20190827.nc4
*** Writing  observations file:  usec3_ptemp_20190827.nc4
 
*** Creating observations file:  usec3_salt_20190827.nc4
*** Writing  observations file:  usec3_salt_20190827.nc4
 
*** Creating observations file:  usec3_uv_codar_20190827.nc4
*** Writing  observations file:  usec3_uv_codar_20190827.nc4
```
>[!NOTE]
>The **native ROMS 4D-Var** file **`usec3km_roms_obs_20190827.nc`** is converted to six **IODA-type** NetCDF-4 files.